### PR TITLE
Fix product model attribute typo

### DIFF
--- a/FlourSync3.API/FlourSync3.API/Models/Products.cs
+++ b/FlourSync3.API/FlourSync3.API/Models/Products.cs
@@ -16,7 +16,7 @@ namespace FlourSync3.API.Models
         [MaxLength(100)] //This attribute specifies the maximum length of the string for this property.
         public string ProductName { get; set; } //Name of the product.
 
-        [Required(ErrorMessage = "Product Category is required."]
+        [Required(ErrorMessage = "Product Category is required.")]
         public string ProductCategory { get; set; } //e.g. "bread", "pastry", etc.
 
         [Required]


### PR DESCRIPTION
## Summary
- fix a missing closing parenthesis in `Products.cs`

## Testing
- `dotnet build FlourSync.sln` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df930e9208330923dca9b3d016405